### PR TITLE
Added functionality to alert mobile users of the game requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <canvas></canvas>
+    <article id="screenSizeAlert">📢 This game is currently only available on desktop, please try again on a supported device or resize your browser window.</article>
     <script src="https://unpkg.com/kaboom@3000.0.1/dist/kaboom.js"></script>
     <script src="src/level1.js"></script>
   </body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,3 +8,19 @@ body {
   background-size: 100%;
   background-repeat: repeat;
 }
+#screenSizeAlert {
+  display: none;
+  color: white;
+  text-align: center;
+  font-size: 30px;
+  margin: 250px 30px;
+  background: black;
+}
+@media(max-width: 631px){
+  canvas {
+    display: none;
+  }
+  #screenSizeAlert {
+    display: block;
+  }
+}


### PR DESCRIPTION
This updated code informs users that the game is meant to be played on a desktop if they are on a device that is too small. The game character movement is only triggered when by clicking specific keys on the keyboard, users won't be able to pull up their keyboard to play on mobile.
<img width="583" alt="Screenshot 2024-03-22 at 09 41 26" src="https://github.com/Game-Invaders/Send-the-Slime/assets/33029825/a9e79c90-8947-475c-826e-24a1170c0f57">
